### PR TITLE
Add Compounding Mechanism section on skill/knowledge building through AI dialogue

### DIFF
--- a/THE_ARCHITECTURE_OF_THOUGHT.tex
+++ b/THE_ARCHITECTURE_OF_THOUGHT.tex
@@ -1177,6 +1177,99 @@ Key practices:
 
 The measure of effective AI collaboration isn't how much you accomplish with AI---it's how much more capable you become through working with AI.
 
+\section{The Compounding Mechanism}\index{Compounding}
+
+Why does the learning stance produce compounding returns while extraction produces only immediate outputs? The answer lies in how dialogue---as opposed to retrieval---shapes cognitive capability.
+
+\subsection{The Reinforcement Loop}
+
+Effective AI dialogue creates a four-stage reinforcement loop:
+
+\begin{enumerate}
+    \item \textbf{Articulation}: You must externalize your thinking to prompt effectively. This act of articulation surfaces gaps, clarifies assumptions, and strengthens neural pathways associated with the concept.
+
+    \item \textbf{Challenge}: The AI's response (especially under Socratic engagement) challenges your formulation. Counterarguments, edge cases, and alternative framings force active processing rather than passive reception.
+
+    \item \textbf{Synthesis}: You integrate the AI's contribution with your existing understanding, resolving tensions and building connections. This synthesis creates durable knowledge structures.
+
+    \item \textbf{Internalization}: Through repeated cycles, patterns become automatic. What once required explicit AI scaffolding becomes implicit capability.
+\end{enumerate}
+
+Each cycle through this loop strengthens the underlying skill. Extraction---asking for answers without engaging the loop---produces outputs but skips the stages where learning actually occurs.
+
+\subsection{Compaction as Cognitive Exercise}\index{Compaction!as learning}
+
+Session compaction (creating \texttt{SESSION\_FINDINGS.md} before context limits) is typically framed as context management. But compaction serves a deeper cognitive function: \emph{forced synthesis}.
+
+When you compress a long exploration into essential findings, you must:
+
+\begin{itemize}
+    \item Distinguish signal from noise
+    \item Identify the core insights worth preserving
+    \item Articulate learnings in transferable form
+    \item Recognize what you now understand that you didn't before
+\end{itemize}
+
+This is effortful processing---the kind that produces durable learning. The act of compaction isn't administrative overhead; it's the moment where scattered exploration crystallizes into knowledge.
+
+\begin{quotebox}
+\textbf{Practice}: Don't wait for context limits to force compaction. Periodically pause extended explorations to ask: ``What have I learned so far? What's the essential insight?'' This deliberate synthesis accelerates internalization.
+\end{quotebox}
+
+\subsection{Research Dialogue: Exploration as Skill-Building}
+
+Using AI for research and exploration---rather than task completion---creates distinct learning dynamics:
+
+\begin{table}[H]
+\centering
+\begin{tabular}{ll}
+\toprule
+\textbf{Task Extraction} & \textbf{Research Dialogue} \\
+\midrule
+``Write this function'' & ``Help me understand this design space'' \\
+Produces artifact & Produces understanding \\
+Single path to output & Multiple paths explored \\
+AI does the work & AI illuminates the territory \\
+Capability unchanged & Capability expanded \\
+\bottomrule
+\end{tabular}
+\caption{Task Extraction vs. Research Dialogue}
+\end{table}
+
+Research dialogue treats AI as a thinking partner for exploration, not a contractor for deliverables. The ``inefficiency'' of exploration is actually investment: you emerge knowing the landscape, not just holding a map someone else drew.
+
+\subsection{Shaping Cognitive Patterns}
+
+Extended AI collaboration shapes how you think, not just what you know:
+
+\begin{itemize}
+    \item \textbf{Question-asking improves}: Repeated Socratic engagement trains you to ask better questions---even without AI
+
+    \item \textbf{Decomposition becomes natural}: Practice breaking problems into promptable pieces transfers to general problem-solving
+
+    \item \textbf{Metacognition strengthens}: Constant reflection on AI outputs builds habitual self-monitoring
+
+    \item \textbf{Synthesis patterns emerge}: Integrating AI contributions with your knowledge becomes a trainable skill
+\end{itemize}
+
+These are not content-specific skills (like learning a programming language) but cognitive patterns that transfer across domains. They represent genuine capability growth, not just knowledge accumulation.
+
+\subsection{The Compound Interest Analogy}
+
+Financial compound interest works because returns are reinvested, producing returns on returns. Cognitive compounding works similarly:
+
+\begin{itemize}
+    \item \textbf{Better questions} → better AI responses → deeper understanding → even better questions
+    \item \textbf{Stronger synthesis} → more integrated knowledge → richer connections → stronger synthesis
+    \item \textbf{Improved metacognition} → better process awareness → more effective collaboration → improved metacognition
+\end{itemize}
+
+Each skill feeds back into the others. Over months and years, the gap between learning-stance practitioners and extraction-mode users widens exponentially---not because one group uses AI more, but because one group uses AI in ways that compound.
+
+\begin{quotebox}
+\textbf{The core insight}: AI dialogue, approached with intentionality, doesn't just produce outputs---it shapes the brain that produces future outputs. Every session is an opportunity for cognitive development, not just task completion.
+\end{quotebox}
+
 \chapter{Building Personal Knowledge Systems}
 
 DCF extends beyond individual interactions to the construction of \textbf{personal knowledge systems}\index{Personal Knowledge Management (PKM)} (PKM)---infrastructures that capture, organize, and compound learning over time. The most effective AI collaborators don't just have good prompting skills; they have well-designed systems for accumulating and retrieving knowledge.
@@ -4846,6 +4939,8 @@ This glossary provides definitions for key terms used throughout this treatise. 
 
 \textbf{Cognitive Scaffolding} --- Temporary AI support that builds human capability over time. Effective scaffolding leads to eventual independence, not permanent dependence.
 
+\textbf{Compounding (Cognitive)}\index{Compounding} --- The phenomenon where AI-assisted learning produces accelerating returns: better questions lead to better responses, which deepen understanding, which enables even better questions. Occurs through the reinforcement loop of articulation, challenge, synthesis, and internalization. Distinguishes learning-stance practitioners from extraction-mode users.
+
 \textbf{Context Window} --- The maximum amount of text an LLM can process in a single interaction. Determines the practical limits of prompt chaining and conversation depth.
 
 \textbf{Critical Rationalism}\index{Critical Rationalism} --- Karl Popper's philosophical stance that all knowledge is provisional, conjectural, and open to revision through criticism. In DCF, provides the foundation for treating AI outputs as hypotheses to be tested rather than truths to be accepted.
@@ -4918,7 +5013,11 @@ This glossary provides definitions for key terms used throughout this treatise. 
 
 \textbf{Recursive Refinement} --- The DCF principle of iteratively improving outputs until they converge on clarity. Each iteration's output becomes the next iteration's input.
 
+\textbf{Reinforcement Loop (Cognitive)} --- The four-stage cycle through which AI dialogue builds durable capability: (1) Articulation---externalizing thinking; (2) Challenge---AI responses that force active processing; (3) Synthesis---integrating new with existing understanding; (4) Internalization---patterns becoming automatic. The mechanism behind cognitive compounding.
+
 \textbf{Reinvention Addiction}\index{Reinvention Addiction} --- The anti-pattern of repeatedly solving the same type of problem from scratch instead of capturing effective patterns as reusable skills. Treats each session as isolated rather than building cumulative capability. See Anti-Pattern 12 in Chapter~\ref{ch:failure-modes}.
+
+\textbf{Research Dialogue} --- Using AI for exploration and understanding rather than task completion. Distinct from extraction: produces understanding rather than artifacts, explores multiple paths, and expands capability rather than leaving it unchanged. Investment that compounds over time.
 
 \textbf{ReAct (Reasoning + Acting)} --- An AI paradigm combining reasoning traces with action execution. Enables LLMs to interact with external tools and environments.
 

--- a/resources/DCF_GLOSSARY.md
+++ b/resources/DCF_GLOSSARY.md
@@ -74,6 +74,15 @@ Questions or conditions embedded in prompts that help AI determine when it has p
 ### Socratic Fatigue
 Exhaustion from over-application of Socratic questioning, occurring when the collaborative energy of productive dialogue masks diminishing returns. The human tendency toward over-perfection when engaged in recursive refinement. Counteracted by designing prompts with escape paths and exit hooks.
 
+### Compounding (Cognitive)
+The phenomenon where AI-assisted learning produces accelerating returns: better questions lead to better responses, which deepen understanding, which enables even better questions. Occurs through the reinforcement loop of articulation, challenge, synthesis, and internalization. Distinguishes learning-stance practitioners from extraction-mode users.
+
+### Reinforcement Loop
+The four-stage cycle through which AI dialogue builds durable capability: (1) Articulation—externalizing thinking; (2) Challenge—AI responses that force active processing; (3) Synthesis—integrating new with existing understanding; (4) Internalization—patterns becoming automatic. The mechanism behind cognitive compounding.
+
+### Research Dialogue
+Using AI for exploration and understanding rather than task completion. Distinct from extraction: produces understanding rather than artifacts, explores multiple paths, and expands capability rather than leaving it unchanged. Investment that compounds over time.
+
 ---
 
 ## Stances


### PR DESCRIPTION
## Summary
- New section "The Compounding Mechanism" in Part V (Learning Stance chapter)
- Explains *why* dialogue produces compounding returns while extraction doesn't
- Reframes compaction from context management to cognitive exercise

## Key Concepts

### The Reinforcement Loop
Four-stage cycle: Articulation → Challenge → Synthesis → Internalization

### Compaction as Cognitive Exercise
- Forced synthesis, not administrative overhead
- "The act of compaction isn't administrative overhead; it's the moment where scattered exploration crystallizes into knowledge"

### Research Dialogue vs Task Extraction
| Task Extraction | Research Dialogue |
|-----------------|-------------------|
| "Write this function" | "Help me understand this design space" |
| Produces artifact | Produces understanding |
| Capability unchanged | Capability expanded |

### Shaping Cognitive Patterns
How extended AI collaboration shapes *how* you think, not just what you know

## Changes
- `THE_ARCHITECTURE_OF_THOUGHT.tex`: New section + 3 glossary entries
- `resources/DCF_GLOSSARY.md`: 3 new terms (Compounding, Reinforcement Loop, Research Dialogue)

## Test plan
- [ ] Verify LaTeX compiles without errors
- [ ] Review section flows naturally after "Integration with Scaffolding Theory"
- [ ] Confirm glossary entries are alphabetically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)