### PR TITLE
Add CODEOWNERS requiring @domelic approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files require approval from @domelic
+* @domelic


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` file designating @domelic as owner of all files
- Combined with branch protection settings, only @domelic can approve PRs to main

## Branch Protection Settings
| Setting | Value |
|---------|-------|
| Require PR | Yes |
| Required approvals | 1 |
| Require code owner review | Yes |
| Enforce for admins | Yes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)