### PR TITLE
Add repository infrastructure: LICENSE, CI, GitHub Pages

### DIFF
--- a/.github/social-preview.svg
+++ b/.github/social-preview.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a2e"/>
+      <stop offset="100%" style="stop-color:#16213e"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1280" height="640" fill="url(#bg)"/>
+
+  <!-- Decorative elements -->
+  <circle cx="100" cy="100" r="200" fill="#0f3460" opacity="0.3"/>
+  <circle cx="1180" cy="540" r="250" fill="#0f3460" opacity="0.3"/>
+
+  <!-- Main title -->
+  <text x="640" y="200" text-anchor="middle" font-family="Georgia, serif" font-size="64" fill="#e94560" font-weight="bold">
+    The Architecture of Thought
+  </text>
+
+  <!-- Subtitle -->
+  <text x="640" y="280" text-anchor="middle" font-family="Arial, sans-serif" font-size="32" fill="#ffffff">
+    The Dialectical Cognition Framework
+  </text>
+
+  <!-- Description -->
+  <text x="640" y="360" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#a0a0a0">
+    A Treatise on Human-AI Collaboration in the Agentic Era
+  </text>
+
+  <!-- Key features -->
+  <text x="640" y="440" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#e94560">
+    Socratic Dialogue • Recursive Refinement • Thinking Mirrors
+  </text>
+
+  <!-- Author -->
+  <text x="640" y="520" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" fill="#707070">
+    Damir Omelic &amp; Claude (Anthropic)
+  </text>
+
+  <!-- Stats -->
+  <text x="640" y="580" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#505050">
+    198 Pages • 16 Principles • 21 Skill Modes • 14 Anti-Patterns
+  </text>
+</svg>

--- a/.github/workflows/compile-pdf.yml
+++ b/.github/workflows/compile-pdf.yml
@@ -1,0 +1,50 @@
+name: Compile PDF
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**.tex'
+      - '**.bib'
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: THE_ARCHITECTURE_OF_THOUGHT.tex
+          latexmk_use_xelatex: false
+          latexmk_shell_escape: false
+          extra_system_packages: "biber"
+          pre_compile: |
+            echo "Compiling THE_ARCHITECTURE_OF_THOUGHT.tex"
+          post_compile: |
+            echo "Compilation complete"
+            ls -la THE_ARCHITECTURE_OF_THOUGHT.pdf
+
+      - name: Check PDF was created
+        run: |
+          if [ -f "THE_ARCHITECTURE_OF_THOUGHT.pdf" ]; then
+            echo "PDF compiled successfully"
+            ls -la THE_ARCHITECTURE_OF_THOUGHT.pdf
+          else
+            echo "PDF compilation failed"
+            exit 1
+          fi
+
+      - name: Commit updated PDF
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add THE_ARCHITECTURE_OF_THOUGHT.pdf
+          git diff --staged --quiet || git commit -m "Auto-compile PDF from LaTeX changes"
+          git push

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,38 @@
+Copyright (c) 2026 Damir Omelic. All Rights Reserved.
+
+THE ARCHITECTURE OF THOUGHT: THE DIALECTICAL COGNITION FRAMEWORK
+
+This work is the intellectual property of the primary author. This document
+was co-authored with Claude, an AI assistant developed by Anthropic. The
+human author retains full intellectual property rights.
+
+PERMISSIONS:
+- You may read and reference this work for personal, educational, and
+  research purposes.
+- You may cite this work in academic papers, articles, and other publications
+  with proper attribution (see README.md for citation formats).
+- You may share links to this repository.
+
+RESTRICTIONS:
+- You may not copy, reproduce, distribute, or create derivative works from
+  this material without explicit written permission from the copyright holder.
+- You may not use this work for commercial purposes without a license.
+- You may not remove or alter any copyright notices or attributions.
+
+CONTRIBUTING:
+Contributions to this repository are welcome under the terms outlined in
+CONTRIBUTING.md. By submitting a contribution, you agree to grant the
+copyright holder a perpetual, worldwide, non-exclusive, royalty-free license
+to use, reproduce, modify, and distribute your contribution as part of this
+work.
+
+For licensing inquiries, please open a GitHub issue or contact the author
+through the repository.
+
+THE SOFTWARE AND DOCUMENTATION ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary
Adds essential repository infrastructure for a well-maintained project.

## Changes

### LICENSE File
- All Rights Reserved license with clear permissions and restrictions
- Contribution terms aligned with CONTRIBUTING.md

### GitHub Actions (CI)
- Automatic PDF compilation when `.tex` or `.bib` files change
- Uses `xu-cheng/latex-action@v3` for LaTeX compilation
- Auto-commits updated PDF to repository

### GitHub Pages
- Enabled via API: https://domelic.github.io/architecture-of-thought/
- Serves README.md as landing page

### Social Preview
- SVG image at `.github/social-preview.svg`
- **Manual step required:** Upload to Settings > Social preview after merge

## Post-Merge Manual Steps
1. Go to **Settings > General > Social preview**
2. Upload `.github/social-preview.svg` (or export as PNG first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)