### PR TITLE
Add community features: Code of Conduct, funding, labels, release automation

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: [domelic]
+# patreon: # Replace with a single Patreon username
+# open_collective: # Replace with a single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name
+# community_bridge: # Replace with a single Community Bridge project-name
+# liberapay: # Replace with a single Liberapay username
+# issuehunt: # Replace with a single IssueHunt username
+# lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name
+# polar: # Replace with a single Polar username
+# buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+# thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags like v1.0.0, v2.1.0, etc.
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        run: |
+          # Extract the section for this version from CHANGELOG.md
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          # Remove 'v' prefix for matching in changelog
+          VERSION_NUM="${VERSION#v}"
+
+          # Extract content between this version header and the next version header
+          NOTES=$(awk "/^## \[${VERSION_NUM}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+
+          # If no notes found, use a default message
+          if [ -z "$NOTES" ]; then
+            NOTES="Release ${VERSION}"
+          fi
+
+          # Write to file to preserve formatting
+          echo "$NOTES" > release_notes.md
+          echo "Release notes extracted"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "DCF ${{ steps.version.outputs.VERSION }}"
+          body_path: release_notes.md
+          files: |
+            THE_ARCHITECTURE_OF_THOUGHT.pdf
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.VERSION, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,56 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in the Dialectical Cognition Framework project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+**Examples of behavior that contributes to a positive environment:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+- Engaging in good faith dialogue (practicing what DCF preaches)
+
+**Examples of unacceptable behavior:**
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## DCF-Specific Guidelines
+
+As a project focused on productive human-AI collaboration and Socratic dialogue, we especially value:
+
+- **Intellectual honesty** — Engage with ideas on their merits, not personalities
+- **Constructive criticism** — Challenge ideas while respecting people
+- **Learning stance** — Approach disagreements as opportunities to understand, not win
+- **Good faith** — Assume others are trying to contribute positively
+
+## Responsibilities
+
+Project maintainers are responsible for clarifying standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, or to ban temporarily or permanently any contributor for behaviors they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when an individual is representing the project or its community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting the project maintainer directly. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0.
+
+---
+
+*From the Dialectical Cognition Framework (DCF)*
+*https://github.com/domelic/architecture-of-thought*


### PR DESCRIPTION
## Summary
Adds community-focused features for project governance and automation.

## Changes

### Code of Conduct
- Based on Contributor Covenant v2.0
- Includes DCF-specific guidelines (intellectual honesty, learning stance, good faith)

### FUNDING.yml
- Enables GitHub Sponsors button
- Configured for @domelic

### Issue Labels (15 total)
| Label | Purpose |
|-------|---------|
| `case-study` | Community case study submissions |
| `treatise` | Main document issues |
| `resources` | Supporting files issues |
| `skill` | /dcf skill mode related |
| `priority: high/low` | Priority levels |
| + standard labels | bug, enhancement, question, etc. |

### Release Automation
- Triggers on version tags (v*)
- Extracts release notes from CHANGELOG.md
- Attaches PDF to release
- Marks pre-releases for tags with `-` (e.g., v2.0.0-beta)

## Usage
To create a release:
```bash
git tag v2.3.0
git push origin v2.3.0
# GitHub Action creates release automatically
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)