### PR TITLE
Add automatic page count updates and dynamic DOI badge

### DIFF
--- a/.github/workflows/compile-pdf.yml
+++ b/.github/workflows/compile-pdf.yml
@@ -41,10 +41,41 @@ jobs:
             exit 1
           fi
 
-      - name: Commit updated PDF
+      - name: Extract and update page count
+        run: |
+          # Install poppler-utils for pdfinfo
+          sudo apt-get update && sudo apt-get install -y poppler-utils
+
+          # Extract page count from PDF
+          PAGE_COUNT=$(pdfinfo THE_ARCHITECTURE_OF_THOUGHT.pdf | grep "Pages:" | awk '{print $2}')
+          echo "Detected page count: $PAGE_COUNT"
+
+          if [ -z "$PAGE_COUNT" ]; then
+            echo "Could not extract page count, skipping update"
+            exit 0
+          fi
+
+          # Update README.md - badge, download link, and repo structure
+          sed -i "s/Pages-[0-9]*-blue/Pages-${PAGE_COUNT}-blue/g" README.md
+          sed -i "s/PDF ([0-9]* pages)/PDF (${PAGE_COUNT} pages)/g" README.md
+          sed -i "s/Compiled document ([0-9]* pages)/Compiled document (${PAGE_COUNT} pages)/g" README.md
+
+          # Update CLAUDE.md - overview and key files table
+          sed -i "s/[0-9]*-page LaTeX document/${PAGE_COUNT}-page LaTeX document/g" CLAUDE.md
+          sed -i "s/([0-9]* pages,/(${PAGE_COUNT} pages,/g" CLAUDE.md
+
+          # Update resources/DCF_SLIDE_DECK.md if it exists
+          if [ -f "resources/DCF_SLIDE_DECK.md" ]; then
+            sed -i "s/([0-9]* pages)/(${PAGE_COUNT} pages)/g" resources/DCF_SLIDE_DECK.md
+          fi
+
+          echo "Page count updated to $PAGE_COUNT in documentation files"
+
+      - name: Commit updated PDF and page counts
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add THE_ARCHITECTURE_OF_THOUGHT.pdf
-          git diff --staged --quiet || git commit -m "Auto-compile PDF from LaTeX changes"
+          git add THE_ARCHITECTURE_OF_THOUGHT.pdf README.md CLAUDE.md
+          git add resources/DCF_SLIDE_DECK.md 2>/dev/null || true
+          git diff --staged --quiet || git commit -m "Auto-compile PDF and update page count"
           git push

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **The Dialectical Cognition Framework (DCF): A Treatise on Human-AI Collaboration in the Agentic Era**
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18275170.svg)](https://doi.org/10.5281/zenodo.18275170)
+[![DOI](https://zenodo.org/badge/1136026127.svg)](https://zenodo.org/badge/latestdoi/1136026127)
 [![GitHub release](https://img.shields.io/github/v/release/domelic/architecture-of-thought)](https://github.com/domelic/architecture-of-thought/releases/latest)
 [![License: All Rights Reserved](https://img.shields.io/badge/License-All%20Rights%20Reserved-red.svg)](LICENSE)
 [![Pages](https://img.shields.io/badge/Pages-198-blue.svg)](THE_ARCHITECTURE_OF_THOUGHT.pdf)


### PR DESCRIPTION
## Summary
- **Automatic page count updates**: When the PDF is compiled, the workflow now extracts the page count and updates it in README.md, CLAUDE.md, and DCF_SLIDE_DECK.md
- **Dynamic DOI badge**: Switched from version-specific DOI to Zenodo's repo-linked badge that automatically shows the latest DOI

## Changes

### compile-pdf.yml
- Added step to install `poppler-utils` and extract page count using `pdfinfo`
- Added sed commands to update page count in documentation files
- Updated commit step to include documentation files

### README.md
- Changed DOI badge from static `10.5281/zenodo.18275170` to dynamic repo-linked format

## How it works

When `.tex` or `.bib` files are pushed to main:
1. PDF is compiled
2. Page count is extracted: `pdfinfo THE_ARCHITECTURE_OF_THOUGHT.pdf | grep "Pages:"`
3. Documentation files are updated with the new count
4. All changes are committed together

## Test plan
- [ ] Verify workflow runs on next `.tex` change
- [ ] Check page count is correctly extracted and updated
- [ ] Verify DOI badge resolves to latest version

---
🤖 Generated with [Claude Code](https://claude.ai/code)