### PR TITLE
Update release workflow to sync CITATION.cff version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,25 +14,50 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: main  # Checkout main to update files
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          VERSION_NUM="${VERSION#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION_NUM=$VERSION_NUM" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION (number: $VERSION_NUM)"
+
+      - name: Update CITATION.cff version
+        run: |
+          VERSION_NUM="${{ steps.version.outputs.VERSION_NUM }}"
+          TODAY=$(date +%Y-%m-%d)
+
+          # Update version and date-released in CITATION.cff
+          sed -i "s/^version: .*/version: \"${VERSION_NUM}\"/" CITATION.cff
+          sed -i "s/^date-released: .*/date-released: \"${TODAY}\"/" CITATION.cff
+
+          echo "Updated CITATION.cff to version $VERSION_NUM, date $TODAY"
+          cat CITATION.cff | grep -E "^version:|^date-released:"
+
+      - name: Commit CITATION.cff update
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add CITATION.cff
+          git diff --staged --quiet || git commit -m "Update CITATION.cff to ${{ steps.version.outputs.VERSION }}"
+          git push origin main
 
       - name: Extract release notes from CHANGELOG
         id: changelog
         run: |
-          # Extract the section for this version from CHANGELOG.md
-          VERSION="${{ steps.version.outputs.VERSION }}"
-          # Remove 'v' prefix for matching in changelog
-          VERSION_NUM="${VERSION#v}"
+          VERSION_NUM="${{ steps.version.outputs.VERSION_NUM }}"
 
           # Extract content between this version header and the next version header
           NOTES=$(awk "/^## \[${VERSION_NUM}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
 
           # If no notes found, use a default message
           if [ -z "$NOTES" ]; then
-            NOTES="Release ${VERSION}"
+            NOTES="Release ${{ steps.version.outputs.VERSION }}"
           fi
 
           # Write to file to preserve formatting


### PR DESCRIPTION
## Summary

Ensures CITATION.cff version and date-released stay synchronized with releases.

## Changes

When a version tag (e.g., `v3.0.0`) is pushed, the release workflow now:

1. **Updates CITATION.cff** with the new version number and today's date
2. **Commits the change** to main branch
3. **Creates the GitHub release** as before

## Why this matters

- CITATION.cff is the machine-readable format GitHub uses for the "Cite this repository" button
- Keeping it synchronized ensures researchers always cite the correct version
- The `date-released` field automatically reflects the actual release date

## Test plan
- [ ] Create a test tag and verify CITATION.cff is updated
- [ ] Verify release is created with correct version

---
🤖 Generated with [Claude Code](https://claude.ai/code)