### PR TITLE
Add release checklist and stale bot workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,48 @@
+name: Mark Stale Issues and PRs
+
+on:
+  schedule:
+    # Run daily at midnight UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark stale issues and PRs
+        uses: actions/stale@v9
+        with:
+          # Issue settings
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            If this issue is still relevant, please comment or remove the stale label.
+          close-issue-message: >
+            This issue was closed because it has been inactive for 60 days.
+            Feel free to reopen if this is still relevant.
+          days-before-issue-stale: 45
+          days-before-issue-close: 14
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'pinned,security,in-progress'
+
+          # PR settings
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            If this PR is still relevant, please comment or remove the stale label.
+          close-pr-message: >
+            This pull request was closed because it has been inactive for 60 days.
+            Feel free to reopen if this is still relevant.
+          days-before-pr-stale: 45
+          days-before-pr-close: 14
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'pinned,in-progress'
+
+          # General settings
+          operations-per-run: 30
+          remove-stale-when-updated: true

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ See [examples/README.md](examples/README.md) for the full collection and contrib
 |------|-------------|
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute to DCF |
 | [CHANGELOG.md](CHANGELOG.md) | Version history and changes |
+| [RELEASING.md](RELEASING.md) | Release process and checklist |
 
 ---
 
@@ -237,6 +238,8 @@ pdflatex THE_ARCHITECTURE_OF_THOUGHT.tex
 ├── DCF_ESSENTIALS.md                 # Condensed practitioner's guide
 ├── CONTRIBUTING.md                   # Contribution guidelines
 ├── CHANGELOG.md                      # Version history
+├── RELEASING.md                      # Release process checklist
+├── CITATION.cff                      # Machine-readable citation
 ├── THE_ARCHITECTURE_OF_THOUGHT.pdf   # Compiled document (198 pages)
 ├── THE_ARCHITECTURE_OF_THOUGHT.tex   # LaTeX source
 ├── references.bib                    # BibTeX bibliography (31 sources)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,100 @@
+# Release Process
+
+This document describes how to create a new release of "The Architecture of Thought."
+
+## Prerequisites
+
+- All changes merged to `main`
+- PDF compiled and up to date
+- CHANGELOG.md updated with release notes
+
+## Release Checklist
+
+### 1. Update CHANGELOG.md
+
+Add a new section at the top of CHANGELOG.md:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- New feature or content
+
+### Changed
+- Modified behavior or content
+
+### Fixed
+- Bug fixes or corrections
+```
+
+### 2. Commit the CHANGELOG
+
+```bash
+git add CHANGELOG.md
+git commit -m "Prepare release vX.Y.Z"
+git push origin main
+```
+
+### 3. Create and Push the Tag
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+### 4. Automated Steps (GitHub Actions)
+
+Once the tag is pushed, the release workflow automatically:
+
+1. **Updates CITATION.cff** — Sets `version` and `date-released` to match the tag
+2. **Extracts release notes** — Pulls the section from CHANGELOG.md
+3. **Creates GitHub Release** — Includes the PDF as a downloadable asset
+4. **Updates Zenodo** — If linked, creates a new DOI version
+
+### 5. Verify the Release
+
+- [ ] Check [Releases page](https://github.com/domelic/architecture-of-thought/releases) for new release
+- [ ] Verify PDF is attached
+- [ ] Verify release notes are correct
+- [ ] Check CITATION.cff was updated on main
+- [ ] Verify Zenodo DOI (if applicable)
+
+## Version Numbering
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (X.0.0) — Significant restructuring or new parts added
+- **MINOR** (0.X.0) — New chapters, sections, or resources
+- **PATCH** (0.0.X) — Corrections, clarifications, typo fixes
+
+## Hotfix Releases
+
+For urgent corrections:
+
+```bash
+git checkout main
+# Make the fix
+git add .
+git commit -m "Fix critical issue in section X"
+git push origin main
+
+# Wait for PDF to compile, then tag
+git pull  # Get the auto-compiled PDF
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+## Rolling Back a Release
+
+If a release needs to be withdrawn:
+
+```bash
+# Delete the tag locally and remotely
+git tag -d vX.Y.Z
+git push origin :refs/tags/vX.Y.Z
+
+# Delete the GitHub release via web UI or CLI
+gh release delete vX.Y.Z --yes
+```
+
+Note: This does not affect already-minted Zenodo DOIs.


### PR DESCRIPTION
## Summary

Final repository improvements: release documentation and automated issue management.

## Changes Made

### RELEASING.md
- Step-by-step release process checklist
- Version numbering guidelines (semantic versioning)
- Hotfix and rollback procedures
- Documents the automated workflow steps

### Stale Bot (.github/workflows/stale.yml)
- Runs daily at midnight UTC
- Marks issues/PRs as stale after 45 days of inactivity
- Closes stale items after 14 more days (60 total)
- Exempt labels: `pinned`, `security`, `in-progress`

### New Labels
- `stale` — Applied by bot to inactive items
- `pinned` — Exempt from stale bot
- `in-progress` — Exempt from stale bot

### README Updates
- Added RELEASING.md and CITATION.cff to project files table
- Updated repository structure diagram

## Discussion Categories
GitHub API doesn't support creating discussion categories programmatically.
Current defaults (Announcements, General, Ideas, Polls, Q&A, Show and tell) are sufficient.
Custom categories can be added via Settings > Discussions if needed.

## Test plan
- [ ] Verify stale bot runs (can trigger manually via workflow_dispatch)
- [ ] Check labels were created
- [ ] Verify RELEASING.md renders correctly

---
🤖 Generated with [Claude Code](https://claude.ai/code)