### PR TITLE
docs: add branch naming conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,49 @@ dcf-workflow decision "API design"    # tradeoffs → challenge → decide
 
 When sessions get long, use `/dcf compact` to create `SESSION_FINDINGS.md` (gitignored) for continuity across session resets.
 
+## Git Workflow
+
+### Branch Naming Convention
+
+When creating branches, use prefixes that match the conventional commit type:
+
+| Type | Branch Prefix | When to Use |
+|------|---------------|-------------|
+| `feat/` | `feat/description` | New content or features |
+| `fix/` | `fix/description` | Corrections and bug fixes |
+| `docs/` | `docs/description` | Documentation changes |
+| `refactor/` | `refactor/description` | Restructuring |
+| `chore/` | `chore/description` | Maintenance tasks |
+| `ci/` | `ci/description` | CI/CD changes |
+
+**Rules:**
+- Use lowercase
+- Use hyphens to separate words (e.g., `feat/multi-agent-patterns`)
+- Keep names concise but descriptive
+
+### Commit Message Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>: <description>
+```
+
+**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `chore`, `ci`
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full details.
+
+### Pull Request Guidelines
+
+- PRs require review before merging
+- All status checks must pass
+- Branches are automatically deleted after merge
+- Squash merge is preferred for clean history
+
 ## For Claude: Working Style
 
-1. **Apply DCF principles**: Surface assumptions, present trade-offs, use questioning to clarify
-2. **Be direct and concise**: Practitioner-focused, not academic verbose
-3. **Ground abstractions in examples**: New theoretical content needs concrete illustrations
-4. **Maintain consistency**: New resources should follow `resources/` file format patterns
+1. **Follow conventions**: Use the branch naming and commit conventions above
+2. **Apply DCF principles**: Surface assumptions, present trade-offs, use questioning to clarify
+3. **Be direct and concise**: Practitioner-focused, not academic verbose
+4. **Ground abstractions in examples**: New theoretical content needs concrete illustrations
+5. **Maintain consistency**: New resources should follow `resources/` file format patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,28 @@ Help grow the DCF community:
 
 ---
 
+## Branch Naming Convention
+
+Branch names should match the conventional commit type:
+
+| Type | Branch Prefix | Example |
+|------|---------------|---------|
+| `feat` | `feat/` | `feat/multi-agent-patterns` |
+| `fix` | `fix/` | `fix/citation-error` |
+| `docs` | `docs/` | `docs/workshop-guide` |
+| `style` | `style/` | `style/formatting` |
+| `refactor` | `refactor/` | `refactor/resources-folder` |
+| `chore` | `chore/` | `chore/update-deps` |
+| `ci` | `ci/` | `ci/add-workflow` |
+
+**Rules:**
+- Use lowercase
+- Use hyphens to separate words
+- Keep names concise but descriptive
+- Branches are automatically deleted after PR merge
+
+---
+
 ## Commit Message Convention
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/) for automated releases. Please format your commit messages as:


### PR DESCRIPTION
## Summary

Add branch naming conventions to ensure consistent branch management across the repository.

## Changes Made

- **CONTRIBUTING.md**: Added branch naming convention section with table of prefixes matching conventional commit types
- **CLAUDE.md**: Added Git Workflow section with:
  - Branch naming conventions for Claude Code to follow
  - Commit message convention summary
  - PR guidelines noting auto-delete branches

## Branch Naming Convention

| Type | Branch Prefix | Example |
|------|---------------|---------|
| `feat` | `feat/` | `feat/multi-agent-patterns` |
| `fix` | `fix/` | `fix/citation-error` |
| `docs` | `docs/` | `docs/workshop-guide` |
| `chore` | `chore/` | `chore/update-deps` |

**Rules:** lowercase, hyphens between words, concise but descriptive

---

Generated with [Claude Code](https://claude.com/claude-code)