### PR TITLE
docs: update repository structure with complete file listing

### DIFF
--- a/.claude/skills/github-release.md
+++ b/.claude/skills/github-release.md
@@ -1,0 +1,113 @@
+# GitHub Release Skill
+
+Create GitHub releases using Playwright browser automation.
+
+## Usage
+
+```text
+/github-release <tag> [title]
+```text
+
+## Examples
+
+```text
+/github-release v3.0.0
+/github-release v2.1.0 "Bug fixes and performance improvements"
+```text
+
+## Instructions
+
+When this skill is invoked, use Playwright to create a GitHub release:
+
+### 1. Navigate to Release Page
+
+```text
+mcp__plugin_playwright_playwright__browser_navigate
+url: https://github.com/{owner}/{repo}/releases/new
+```text
+
+Get owner/repo from the current git remote:
+```bash
+git remote get-url origin
+```text
+
+### 2. Select the Tag
+
+1. Click the tag selector button (look for "Tag: Select tag")
+2. Click the tag from the dropdown list
+3. If tag doesn't exist, type it in the search box and click "Create new tag"
+
+### 3. Enter Release Title
+
+Type in the release title textbox. If no title provided, use:
+```text
+{tag} - {first line of tag annotation message}
+```text
+
+Get tag message with:
+```bash
+git tag -l --format='%(contents:subject)' {tag}
+```text
+
+### 4. Enter Release Description
+
+Generate release notes from CHANGELOG.md if available:
+1. Read CHANGELOG.md
+2. Find the section for this version
+3. Format as markdown for GitHub
+
+If no CHANGELOG, use the tag annotation message:
+```bash
+git tag -l --format='%(contents:body)' {tag}
+```text
+
+### 5. Publish
+
+1. Ensure "Set as the latest release" is checked (default)
+2. Click "Publish release" button
+3. Verify the release page loads with the new release
+
+### 6. Close Browser
+
+```text
+mcp__plugin_playwright_playwright__browser_close
+```text
+
+## Playwright Element References
+
+Common elements on the GitHub release page:
+
+| Element | Typical Action |
+|---------|---------------|
+| Tag selector button | Click to open dropdown |
+| Tag option in list | Click to select (menuitemradio) |
+| Title textbox | Type release title |
+| Description textbox | Type release notes (markdown) |
+| "Set as latest" checkbox | Usually pre-checked |
+| "Publish release" button | Click to publish |
+
+## Prerequisites
+
+- Git tag must exist (create with `git tag -a {tag} -m "message"`)
+- Tag must be pushed to remote (`git push origin {tag}`)
+- User must be authenticated to GitHub in the browser
+- Playwright MCP server must be available
+
+## Post-Release
+
+After publishing:
+- GitHub Release badge in README auto-updates
+- Zenodo archives automatically (if integration enabled)
+- DOI resolves to new version
+
+## Error Handling
+
+If tag doesn't appear in dropdown:
+1. Verify tag was pushed: `git ls-remote --tags origin`
+2. Refresh the page and try again
+3. Create tag directly in GitHub UI if needed
+
+If publish fails:
+1. Check for required fields (title is required)
+2. Verify user has write access to repository
+3. Check for rate limiting

--- a/README.md
+++ b/README.md
@@ -235,24 +235,50 @@ pdflatex THE_ARCHITECTURE_OF_THOUGHT.tex
 ```text
 /
 ├── README.md                         # This file
+├── LICENSE                           # All Rights Reserved license
 ├── CLAUDE.md                         # Claude Code project instructions
 ├── DCF_ESSENTIALS.md                 # Condensed practitioner's guide
 ├── CONTRIBUTING.md                   # Contribution guidelines
-├── CHANGELOG.md                      # Version history
+├── CODE_OF_CONDUCT.md                # Community guidelines
+├── CHANGELOG.md                      # Version history (auto-generated)
 ├── RELEASING.md                      # Release process checklist
 ├── CITATION.cff                      # Machine-readable citation
 ├── THE_ARCHITECTURE_OF_THOUGHT.pdf   # Compiled document (198 pages)
 ├── THE_ARCHITECTURE_OF_THOUGHT.tex   # LaTeX source
 ├── references.bib                    # BibTeX bibliography (31 sources)
+├── commitlint.config.js              # Conventional commit enforcement
+├── release-please-config.json        # Release automation config
 ├── assets/
 │   └── cover.jpg                     # Book cover image
-├── docs/
+├── docs/                             # Private documentation (gitignored)
 │   ├── AMAZON_KDP_CONTENT.md         # KDP metadata and description
 │   ├── AMAZON_PUBLISHING_GUIDE.md    # Full publishing documentation
 │   └── CLAUDE_CODE_SKILLS.md         # Claude Code skill development guide
+├── .github/
+│   ├── CODEOWNERS                    # Code ownership definitions
+│   ├── FUNDING.yml                   # Sponsorship configuration
+│   ├── PULL_REQUEST_TEMPLATE.md      # PR template
+│   ├── dependabot.yml                # Dependency update automation
+│   ├── social-preview.svg            # Repository social image
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug_report.md             # Bug report template
+│   │   ├── feature_request.md        # Feature request template
+│   │   ├── case_study.md             # Case study submission template
+│   │   └── config.yml                # Template chooser config
+│   └── workflows/
+│       ├── release-please.yml        # Automated releases
+│       ├── amazon-kdp-publish.yml    # EPUB build on release
+│       ├── commitlint.yml            # Commit message validation
+│       ├── markdown-lint.yml         # Markdown formatting
+│       ├── spell-check.yml           # Spelling validation
+│       ├── link-checker.yml          # Broken link detection
+│       ├── compile-pdf.yml           # LaTeX compilation
+│       ├── pdf-preview.yml           # PR artifact preview
+│       ├── stale.yml                 # Inactive issue management
+│       └── welcome.yml               # New contributor greeting
 ├── .claude/
 │   ├── skills/
-│   │   ├── dcf.md                    # Claude Code skill for DCF (principle-based)
+│   │   ├── dcf.md                    # Claude Code skill for DCF
 │   │   ├── github-release.md         # Skill for creating GitHub releases
 │   │   └── archive/
 │   │       └── dcf-procedural.md     # Legacy procedural version


### PR DESCRIPTION
## Summary
- Add github-release.md skill to git tracking (was previously untracked)
- Update README.md repository structure diagram to include:
  - LICENSE and CODE_OF_CONDUCT.md at root
  - Complete .github/ directory (workflows, templates, configs)
  - Config files (commitlint, release-please)
  - Note docs/ as gitignored private documentation

## Type of Change
- [x] Documentation

## Checklist
- [x] Commits follow conventional format

🤖 Generated with [Claude Code](https://claude.com/claude-code)