### PR TITLE
fix: remove docs/ from README structure (gitignored)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,6 @@ pdflatex THE_ARCHITECTURE_OF_THOUGHT.tex
 ├── release-please-config.json        # Release automation config
 ├── assets/
 │   └── cover.jpg                     # Book cover image
-├── docs/                             # Private documentation (gitignored)
-│   ├── AMAZON_KDP_CONTENT.md         # KDP metadata and description
-│   ├── AMAZON_PUBLISHING_GUIDE.md    # Full publishing documentation
-│   └── CLAUDE_CODE_SKILLS.md         # Claude Code skill development guide
 ├── .github/
 │   ├── CODEOWNERS                    # Code ownership definitions
 │   ├── FUNDING.yml                   # Sponsorship configuration

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -155,5 +155,5 @@ Amazon KDP has no public API for automated uploads. The workflow automates every
 
 - [KDP Dashboard](https://kdp.amazon.com)
 - [Kindle Previewer](https://www.amazon.com/kindlepreviewer)
-- [AMAZON_PUBLISHING_GUIDE.md](docs/AMAZON_PUBLISHING_GUIDE.md) — Full publishing documentation
-- [AMAZON_KDP_CONTENT.md](docs/AMAZON_KDP_CONTENT.md) — Ready-to-use KDP content
+- `docs/AMAZON_PUBLISHING_GUIDE.md` — Full publishing documentation (local only, gitignored)
+- `docs/AMAZON_KDP_CONTENT.md` — Ready-to-use KDP content (local only, gitignored)


### PR DESCRIPTION
## Summary
- Remove `docs/` directory from repository structure in README.md (all files are gitignored, not visible on GitHub)
- Update RELEASING.md to note docs/ files are local-only instead of broken links

## Type of Change
- [x] Documentation fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)