### PR TITLE
fix: remove docs/ references (gitignored, not visible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,6 @@ pdflatex THE_ARCHITECTURE_OF_THOUGHT.tex
 ├── release-please-config.json        # Release automation config
 ├── assets/
 │   └── cover.jpg                     # Book cover image
-├── docs/                             # Private documentation (gitignored)
-│   ├── AMAZON_KDP_CONTENT.md         # KDP metadata and description
-│   ├── AMAZON_PUBLISHING_GUIDE.md    # Full publishing documentation
-│   └── CLAUDE_CODE_SKILLS.md         # Claude Code skill development guide
 ├── .github/
 │   ├── CODEOWNERS                    # Code ownership definitions
 │   ├── FUNDING.yml                   # Sponsorship configuration

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -155,5 +155,3 @@ Amazon KDP has no public API for automated uploads. The workflow automates every
 
 - [KDP Dashboard](https://kdp.amazon.com)
 - [Kindle Previewer](https://www.amazon.com/kindlepreviewer)
-- [AMAZON_PUBLISHING_GUIDE.md](docs/AMAZON_PUBLISHING_GUIDE.md) — Full publishing documentation
-- [AMAZON_KDP_CONTENT.md](docs/AMAZON_KDP_CONTENT.md) — Ready-to-use KDP content


### PR DESCRIPTION
## Summary
- Remove `docs/` from README repository structure (files are gitignored)
- Remove broken links to docs/ files in RELEASING.md
- These files are local-only and superseded by CI automation

## Type of Change
- [x] Documentation fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)