### PR TITLE
fix: upload PDF before CITATION.cff update in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,7 +37,16 @@ jobs:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload PDF to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
+            THE_ARCHITECTURE_OF_THOUGHT.pdf \
+            --clobber
+
       - name: Update CITATION.cff
+        continue-on-error: true
         run: |
           VERSION="${{ needs.release-please.outputs.version }}"
           TODAY=$(date +%Y-%m-%d)
@@ -48,18 +57,9 @@ jobs:
 
           echo "Updated CITATION.cff to version $VERSION, date $TODAY"
 
-      - name: Commit CITATION.cff update
-        run: |
+          # Commit and push (may fail due to branch protection)
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add CITATION.cff
-          git diff --staged --quiet || git commit -m "chore: update CITATION.cff to v${{ needs.release-please.outputs.version }}"
-          git push origin main
-
-      - name: Upload PDF to release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload "${{ needs.release-please.outputs.tag_name }}" \
-            THE_ARCHITECTURE_OF_THOUGHT.pdf \
-            --clobber
+          git diff --staged --quiet || git commit -m "chore: update CITATION.cff to v${VERSION}"
+          git push origin main || echo "::warning::Could not push CITATION.cff update - branch protection requires PR"


### PR DESCRIPTION
## Summary
The post-release job was failing because branch protection blocks the CITATION.cff direct push, and the PDF upload step never ran.

**Changes:**
- Reorder steps so PDF upload happens first
- Add `continue-on-error: true` to CITATION.cff step
- PDF will now be uploaded even if CITATION.cff update fails

**Also manually uploaded PDF to:**
- v2.3.0
- v2.3.1

## Type of Change
- [x] Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)